### PR TITLE
Napraw problem z zapisem enrollment po płatności

### DIFF
--- a/supabase_rpc_function.sql
+++ b/supabase_rpc_function.sql
@@ -1,0 +1,42 @@
+-- Funkcja RPC do dodawania enrollment z uprawnieniami serwera
+-- Ta funkcja omija RLS i pozwala backendowi na dodawanie enrollment
+
+CREATE OR REPLACE FUNCTION add_enrollment_for_payment(
+  p_user_id UUID,
+  p_course_id INTEGER
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER -- Uruchamia funkcję z uprawnieniami właściciela (omija RLS)
+AS $$
+DECLARE
+  result_record RECORD;
+  result_json JSON;
+BEGIN
+  -- Dodaj lub zaktualizuj enrollment
+  INSERT INTO enrollments (user_id, course_id, access_granted, enrolled_at)
+  VALUES (p_user_id, p_course_id, true, NOW())
+  ON CONFLICT (user_id, course_id) 
+  DO UPDATE SET 
+    access_granted = true,
+    enrolled_at = NOW()
+  RETURNING * INTO result_record;
+  
+  -- Konwertuj wynik na JSON
+  SELECT row_to_json(result_record) INTO result_json;
+  
+  RETURN result_json;
+EXCEPTION
+  WHEN OTHERS THEN
+    -- Zwróć błąd w formacie JSON
+    RETURN json_build_object(
+      'error', true,
+      'message', SQLERRM,
+      'code', SQLSTATE
+    );
+END;
+$$;
+
+-- Nadaj uprawnienia do wykonywania funkcji dla roli anon i authenticated
+GRANT EXECUTE ON FUNCTION add_enrollment_for_payment(UUID, INTEGER) TO anon;
+GRANT EXECUTE ON FUNCTION add_enrollment_for_payment(UUID, INTEGER) TO authenticated;


### PR DESCRIPTION
Implement Supabase RPC and explicit Stripe line item retrieval to correctly add course enrollments after successful payments.

The previous setup failed to add enrollments because the backend, using `SUPABASE_ANON_KEY`, was restricted by RLS policies that required a user session (`auth.uid()`). Additionally, Stripe webhooks did not automatically provide `line_items`, making it difficult to identify purchased courses. This PR introduces a `SECURITY DEFINER` Supabase RPC function to bypass RLS for enrollment creation and explicitly fetches `line_items` from Stripe to ensure accurate course assignment.

---
<a href="https://cursor.com/background-agent?bcId=bc-a104bb8b-2c19-44f0-aacc-cf586eb0d317">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a104bb8b-2c19-44f0-aacc-cf586eb0d317">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

